### PR TITLE
Movie Endpoints fix 

### DIFF
--- a/pages/js/api-tmdb-test.js
+++ b/pages/js/api-tmdb-test.js
@@ -97,3 +97,4 @@ export const Genres = {
   getTVByGenre: (genreId, page = 1) => 
     makeRequest("/discover/tv", { with_genres: genreId, page }),
 };
+


### PR DESCRIPTION
GetReviews was mis-named by mistake and would affect the display of cast in detail page. Renamed correctly - everything back to working!